### PR TITLE
Test suite compatibility with Sprockets 3.0.0–3.7.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 rvm:
-  - 2.1
-
+  - 2.1.8
+  - 2.2.4
+  - 2.3.0
 gemfile:
   - Gemfile
   - test/gemfiles/Gemfile.rails-4.0.x

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ gemspec
 gem 'actionpack', github: 'github/rails', branch: '3-2-github'
 gem 'railties', github: 'github/rails', branch: '3-2-github'
 gem 'tzinfo'
+gem 'test-unit-minitest', '~> 0.9.1'

--- a/sprockets-rails.gemspec
+++ b/sprockets-rails.gemspec
@@ -14,10 +14,7 @@ Gem::Specification.new do |s|
   s.add_dependency "sprockets", ">= 3.0.0", "< 4.0.0.a"
   s.add_dependency "actionpack", ">= 3.2"
   s.add_dependency "activesupport", ">= 3.2"
-  s.add_development_dependency "railties", ">= 3.2"
-  s.add_development_dependency "rake"
-  s.add_development_dependency "sass"
-  s.add_development_dependency "uglifier"
+  s.add_development_dependency "rake", "~> 10.5.0"
 
   s.author = "Joshua Peek"
   s.email  = "josh@joshpeek.com"

--- a/sprockets-rails.gemspec
+++ b/sprockets-rails.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["README.md", "lib/**/*.rb", "LICENSE"]
 
-  s.add_dependency "sprockets", ">= 3.0.0.beta", "< 4.0"
+  s.add_dependency "sprockets", ">= 3.0.0", "< 4.0.0.a"
   s.add_dependency "actionpack", ">= 3.2"
   s.add_dependency "activesupport", ">= 3.2"
   s.add_development_dependency "railties", ">= 3.2"

--- a/test/gemfiles/Gemfile.rails-4.0.x
+++ b/test/gemfiles/Gemfile.rails-4.0.x
@@ -3,3 +3,4 @@ gemspec :path => "./../.."
 
 gem "actionpack", "~> 4.0.0"
 gem "railties", "~> 4.0.0"
+gem "test-unit-minitest", "~> 0.9.1"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -44,6 +44,7 @@ class HelperTest < ActionView::TestCase
     @logo_digest    = @assets['logo.png'].digest
 
     @dependency_js_digest  = @assets['dependency.js'].digest
+    @dependency_js_debug_digest = @assets['dependency.self.js'].digest
     @dependency_css_digest = @assets['dependency.css'].digest
     @file1_js_digest       = @assets['file1.js'].digest
     @file1_js_debug_digest = @assets['file1.self.js'].digest
@@ -495,7 +496,7 @@ class DebugDigestHelperTest < NoHostHelperTest
       @view.javascript_include_tag(:foo)
     assert_dom_equal %(<script src="/assets/foo.self-#{@foo_js_digest}.js?body=1"></script>\n<script src="/assets/bar.self-#{@bar_js_debug_digest}.js?body=1"></script>),
       @view.javascript_include_tag(:bar)
-    assert_dom_equal %(<script src="/assets/dependency.self-#{@dependency_js_digest}.js?body=1"></script>\n<script src="/assets/file1.self-#{@file1_js_debug_digest}.js?body=1"></script>\n<script src="/assets/file2.self-#{@file2_js_debug_digest}.js?body=1"></script>),
+    assert_dom_equal %(<script src="/assets/dependency.self-#{@dependency_js_debug_digest}.js?body=1"></script>\n<script src="/assets/file1.self-#{@file1_js_debug_digest}.js?body=1"></script>\n<script src="/assets/file2.self-#{@file2_js_debug_digest}.js?body=1"></script>),
       @view.javascript_include_tag(:file1, :file2)
 
     assert_servable_asset_url "/assets/foo-#{@foo_js_digest}.js?body=1"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -36,11 +36,15 @@ class HelperTest < ActionView::TestCase
     @assets.context_class.config        = @view.config
 
     @foo_js_digest  = @assets['foo.js'].digest
+    @foo_js_integrity = @assets['foo.js'].integrity
     @foo_css_digest = @assets['foo.css'].digest
+    @foo_css_integrity = @assets['foo.css'].integrity
     @bar_js_digest  = @assets['bar.js'].digest
     @bar_js_debug_digest = @assets['bar.self.js'].digest
+    @bar_js_integrity = @assets['bar.js'].integrity
     @bar_css_digest = @assets['bar.css'].digest
     @bar_css_debug_digest = @assets['bar.self.css'].digest
+    @bar_css_integrity = @assets['bar.css'].integrity
     @logo_digest    = @assets['logo.png'].digest
 
     @dependency_js_digest  = @assets['dependency.js'].digest
@@ -371,14 +375,14 @@ class DigestHelperTest < NoHostHelperTest
     assert_dom_equal %(<script src="/assets/foo-#{@foo_js_digest}.js"></script>),
       @view.javascript_include_tag("foo", integrity: nil)
 
-    assert_dom_equal %(<script src="/assets/foo-#{@foo_js_digest}.js" integrity="ni:///sha-256;TvVUHzSfftWg1rcfL6TIJ0XKEGrgLyEq6lEpcmrG9qs?ct=application/javascript"></script>),
+    assert_dom_equal %(<script src="/assets/foo-#{@foo_js_digest}.js" integrity="#{@foo_js_integrity}"></script>),
       @view.javascript_include_tag("foo", integrity: true)
-    assert_dom_equal %(<script src="/assets/foo-#{@foo_js_digest}.js" integrity="ni:///sha-256;TvVUHzSfftWg1rcfL6TIJ0XKEGrgLyEq6lEpcmrG9qs?ct=application/javascript"></script>),
+    assert_dom_equal %(<script src="/assets/foo-#{@foo_js_digest}.js" integrity="#{@foo_js_integrity}"></script>),
       @view.javascript_include_tag("foo.js", integrity: true)
-    assert_dom_equal %(<script src="/assets/foo-#{@foo_js_digest}.js" integrity="ni:///sha-256;TvVUHzSfftWg1rcfL6TIJ0XKEGrgLyEq6lEpcmrG9qs?ct=application/javascript"></script>),
+    assert_dom_equal %(<script src="/assets/foo-#{@foo_js_digest}.js" integrity="#{@foo_js_integrity}"></script>),
       @view.javascript_include_tag(:foo, integrity: true)
 
-    assert_dom_equal %(<script src="/assets/foo-#{@foo_js_digest}.js" integrity="ni:///sha-256;TvVUHzSfftWg1rcfL6TIJ0XKEGrgLyEq6lEpcmrG9qs?ct=application/javascript"></script>\n<script src="/assets/bar-#{@bar_js_digest}.js" integrity="ni:///sha-256;g0JYFeYSYGXe376R0JrRzS6CpYpC1HiqtwBsVt_XAWU?ct=application/javascript"></script>),
+    assert_dom_equal %(<script src="/assets/foo-#{@foo_js_digest}.js" integrity="#{@foo_js_integrity}"></script>\n<script src="/assets/bar-#{@bar_js_digest}.js" integrity="#{@bar_js_integrity}"></script>),
       @view.javascript_include_tag(:foo, :bar, integrity: true)
   end
 
@@ -390,14 +394,14 @@ class DigestHelperTest < NoHostHelperTest
     assert_dom_equal %(<link href="/assets/foo-#{@foo_css_digest}.css" media="screen" rel="stylesheet" />),
       @view.stylesheet_link_tag("foo", integrity: nil)
 
-    assert_dom_equal %(<link href="/assets/foo-#{@foo_css_digest}.css" media="screen" rel="stylesheet" integrity="ni:///sha-256;5YzTQPuOJz_EpeXfN_-v1sxsjAj_dw8q26abiHZM3A4?ct=text/css" />),
+    assert_dom_equal %(<link href="/assets/foo-#{@foo_css_digest}.css" media="screen" rel="stylesheet" integrity="#{@foo_css_integrity}" />),
       @view.stylesheet_link_tag("foo", integrity: true)
-    assert_dom_equal %(<link href="/assets/foo-#{@foo_css_digest}.css" media="screen" rel="stylesheet" integrity="ni:///sha-256;5YzTQPuOJz_EpeXfN_-v1sxsjAj_dw8q26abiHZM3A4?ct=text/css" />),
+    assert_dom_equal %(<link href="/assets/foo-#{@foo_css_digest}.css" media="screen" rel="stylesheet" integrity="#{@foo_css_integrity}" />),
       @view.stylesheet_link_tag("foo.css", integrity: true)
-    assert_dom_equal %(<link href="/assets/foo-#{@foo_css_digest}.css" media="screen" rel="stylesheet" integrity="ni:///sha-256;5YzTQPuOJz_EpeXfN_-v1sxsjAj_dw8q26abiHZM3A4?ct=text/css" />),
+    assert_dom_equal %(<link href="/assets/foo-#{@foo_css_digest}.css" media="screen" rel="stylesheet" integrity="#{@foo_css_integrity}" />),
       @view.stylesheet_link_tag(:foo, integrity: true)
 
-    assert_dom_equal %(<link href="/assets/foo-#{@foo_css_digest}.css" media="screen" rel="stylesheet" integrity="ni:///sha-256;5YzTQPuOJz_EpeXfN_-v1sxsjAj_dw8q26abiHZM3A4?ct=text/css" />\n<link href="/assets/bar-#{@bar_css_digest}.css" media="screen" rel="stylesheet" integrity="ni:///sha-256;Vd370-VAW4D96CVpZcjFLXyeHoagI0VHwofmzRXetuE?ct=text/css" />),
+    assert_dom_equal %(<link href="/assets/foo-#{@foo_css_digest}.css" media="screen" rel="stylesheet" integrity="#{@foo_css_integrity}" />\n<link href="/assets/bar-#{@bar_css_digest}.css" media="screen" rel="stylesheet" integrity="#{@bar_css_integrity}" />),
       @view.stylesheet_link_tag(:foo, :bar, integrity: true)
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -428,11 +428,11 @@ class DebugHelperTest < NoHostHelperTest
   def test_javascript_include_tag
     super
 
-    assert_dom_equal %(<script src="/assets/foo.js?body=1"></script>),
+    assert_dom_equal %(<script src="/assets/foo.self.js?body=1"></script>),
       @view.javascript_include_tag(:foo)
-    assert_dom_equal %(<script src="/assets/foo.js?body=1"></script>\n<script src="/assets/bar.js?body=1"></script>),
+    assert_dom_equal %(<script src="/assets/foo.self.js?body=1"></script>\n<script src="/assets/bar.self.js?body=1"></script>),
       @view.javascript_include_tag(:bar)
-    assert_dom_equal %(<script src="/assets/dependency.js?body=1"></script>\n<script src="/assets/file1.js?body=1"></script>\n<script src="/assets/file2.js?body=1"></script>),
+    assert_dom_equal %(<script src="/assets/dependency.self.js?body=1"></script>\n<script src="/assets/file1.self.js?body=1"></script>\n<script src="/assets/file2.self.js?body=1"></script>),
       @view.javascript_include_tag(:file1, :file2)
 
     assert_servable_asset_url "/assets/foo.js?body=1"
@@ -445,11 +445,11 @@ class DebugHelperTest < NoHostHelperTest
   def test_stylesheet_link_tag
     super
 
-    assert_dom_equal %(<link href="/assets/foo.css?body=1" media="screen" rel="stylesheet" />),
+    assert_dom_equal %(<link href="/assets/foo.self.css?body=1" media="screen" rel="stylesheet" />),
       @view.stylesheet_link_tag(:foo)
-    assert_dom_equal %(<link href="/assets/foo.css?body=1" media="screen" rel="stylesheet" />\n<link href="/assets/bar.css?body=1" media="screen" rel="stylesheet" />),
+    assert_dom_equal %(<link href="/assets/foo.self.css?body=1" media="screen" rel="stylesheet" />\n<link href="/assets/bar.self.css?body=1" media="screen" rel="stylesheet" />),
       @view.stylesheet_link_tag(:bar)
-    assert_dom_equal %(<link href="/assets/dependency.css?body=1" media="screen" rel="stylesheet" />\n<link href="/assets/file1.css?body=1" media="screen" rel="stylesheet" />\n<link href="/assets/file2.css?body=1" media="screen" rel="stylesheet" />),
+    assert_dom_equal %(<link href="/assets/dependency.self.css?body=1" media="screen" rel="stylesheet" />\n<link href="/assets/file1.self.css?body=1" media="screen" rel="stylesheet" />\n<link href="/assets/file2.self.css?body=1" media="screen" rel="stylesheet" />),
       @view.stylesheet_link_tag(:file1, :file2)
 
     assert_servable_asset_url "/assets/foo.css?body=1"
@@ -485,11 +485,11 @@ class DebugDigestHelperTest < NoHostHelperTest
   def test_javascript_include_tag
     super
 
-    assert_dom_equal %(<script src="/assets/foo-#{@foo_js_digest}.js?body=1"></script>),
+    assert_dom_equal %(<script src="/assets/foo.self-#{@foo_js_digest}.js?body=1"></script>),
       @view.javascript_include_tag(:foo)
-    assert_dom_equal %(<script src="/assets/foo-#{@foo_js_digest}.js?body=1"></script>\n<script src="/assets/bar-#{@bar_js_digest}.js?body=1"></script>),
+    assert_dom_equal %(<script src="/assets/foo.self-#{@foo_js_digest}.js?body=1"></script>\n<script src="/assets/bar.self-#{@bar_js_digest}.js?body=1"></script>),
       @view.javascript_include_tag(:bar)
-    assert_dom_equal %(<script src="/assets/dependency-#{@dependency_js_digest}.js?body=1"></script>\n<script src="/assets/file1-#{@file1_js_digest}.js?body=1"></script>\n<script src="/assets/file2-#{@file1_js_digest}.js?body=1"></script>),
+    assert_dom_equal %(<script src="/assets/dependency.self-#{@dependency_js_digest}.js?body=1"></script>\n<script src="/assets/file1.self-#{@file1_js_digest}.js?body=1"></script>\n<script src="/assets/file2.self-#{@file1_js_digest}.js?body=1"></script>),
       @view.javascript_include_tag(:file1, :file2)
 
     assert_servable_asset_url "/assets/foo-#{@foo_js_digest}.js?body=1"
@@ -502,11 +502,11 @@ class DebugDigestHelperTest < NoHostHelperTest
   def test_stylesheet_link_tag
     super
 
-    assert_dom_equal %(<link href="/assets/foo-#{@foo_css_digest}.css?body=1" media="screen" rel="stylesheet" />),
+    assert_dom_equal %(<link href="/assets/foo.self-#{@foo_css_digest}.css?body=1" media="screen" rel="stylesheet" />),
       @view.stylesheet_link_tag(:foo)
-    assert_dom_equal %(<link href="/assets/foo-#{@foo_css_digest}.css?body=1" media="screen" rel="stylesheet" />\n<link href="/assets/bar-#{@bar_css_digest}.css?body=1" media="screen" rel="stylesheet" />),
+    assert_dom_equal %(<link href="/assets/foo.self-#{@foo_css_digest}.css?body=1" media="screen" rel="stylesheet" />\n<link href="/assets/bar.self-#{@bar_css_digest}.css?body=1" media="screen" rel="stylesheet" />),
       @view.stylesheet_link_tag(:bar)
-    assert_dom_equal %(<link href="/assets/dependency-#{@dependency_css_digest}.css?body=1" media="screen" rel="stylesheet" />\n<link href="/assets/file1-#{@file1_css_digest}.css?body=1" media="screen" rel="stylesheet" />\n<link href="/assets/file2-#{@file2_css_digest}.css?body=1" media="screen" rel="stylesheet" />),
+    assert_dom_equal %(<link href="/assets/dependency.self-#{@dependency_css_digest}.css?body=1" media="screen" rel="stylesheet" />\n<link href="/assets/file1.self-#{@file1_css_digest}.css?body=1" media="screen" rel="stylesheet" />\n<link href="/assets/file2.self-#{@file2_css_digest}.css?body=1" media="screen" rel="stylesheet" />),
       @view.stylesheet_link_tag(:file1, :file2)
 
     assert_servable_asset_url "/assets/foo-#{@foo_css_digest}.css?body=1"

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -38,15 +38,21 @@ class HelperTest < ActionView::TestCase
     @foo_js_digest  = @assets['foo.js'].digest
     @foo_css_digest = @assets['foo.css'].digest
     @bar_js_digest  = @assets['bar.js'].digest
+    @bar_js_debug_digest = @assets['bar.self.js'].digest
     @bar_css_digest = @assets['bar.css'].digest
+    @bar_css_debug_digest = @assets['bar.self.css'].digest
     @logo_digest    = @assets['logo.png'].digest
 
     @dependency_js_digest  = @assets['dependency.js'].digest
     @dependency_css_digest = @assets['dependency.css'].digest
     @file1_js_digest       = @assets['file1.js'].digest
+    @file1_js_debug_digest = @assets['file1.self.js'].digest
     @file1_css_digest      = @assets['file1.css'].digest
+    @file1_css_debug_digest = @assets['file1.self.css'].digest
     @file2_js_digest       = @assets['file2.js'].digest
+    @file2_js_debug_digest = @assets['file2.self.js'].digest
     @file2_css_digest      = @assets['file2.css'].digest
+    @file2_css_debug_digest = @assets['file2.self.css'].digest
   end
 
   def test_truth
@@ -487,9 +493,9 @@ class DebugDigestHelperTest < NoHostHelperTest
 
     assert_dom_equal %(<script src="/assets/foo.self-#{@foo_js_digest}.js?body=1"></script>),
       @view.javascript_include_tag(:foo)
-    assert_dom_equal %(<script src="/assets/foo.self-#{@foo_js_digest}.js?body=1"></script>\n<script src="/assets/bar.self-#{@bar_js_digest}.js?body=1"></script>),
+    assert_dom_equal %(<script src="/assets/foo.self-#{@foo_js_digest}.js?body=1"></script>\n<script src="/assets/bar.self-#{@bar_js_debug_digest}.js?body=1"></script>),
       @view.javascript_include_tag(:bar)
-    assert_dom_equal %(<script src="/assets/dependency.self-#{@dependency_js_digest}.js?body=1"></script>\n<script src="/assets/file1.self-#{@file1_js_digest}.js?body=1"></script>\n<script src="/assets/file2.self-#{@file1_js_digest}.js?body=1"></script>),
+    assert_dom_equal %(<script src="/assets/dependency.self-#{@dependency_js_digest}.js?body=1"></script>\n<script src="/assets/file1.self-#{@file1_js_debug_digest}.js?body=1"></script>\n<script src="/assets/file2.self-#{@file2_js_debug_digest}.js?body=1"></script>),
       @view.javascript_include_tag(:file1, :file2)
 
     assert_servable_asset_url "/assets/foo-#{@foo_js_digest}.js?body=1"
@@ -504,9 +510,9 @@ class DebugDigestHelperTest < NoHostHelperTest
 
     assert_dom_equal %(<link href="/assets/foo.self-#{@foo_css_digest}.css?body=1" media="screen" rel="stylesheet" />),
       @view.stylesheet_link_tag(:foo)
-    assert_dom_equal %(<link href="/assets/foo.self-#{@foo_css_digest}.css?body=1" media="screen" rel="stylesheet" />\n<link href="/assets/bar.self-#{@bar_css_digest}.css?body=1" media="screen" rel="stylesheet" />),
+    assert_dom_equal %(<link href="/assets/foo.self-#{@foo_css_digest}.css?body=1" media="screen" rel="stylesheet" />\n<link href="/assets/bar.self-#{@bar_css_debug_digest}.css?body=1" media="screen" rel="stylesheet" />),
       @view.stylesheet_link_tag(:bar)
-    assert_dom_equal %(<link href="/assets/dependency.self-#{@dependency_css_digest}.css?body=1" media="screen" rel="stylesheet" />\n<link href="/assets/file1.self-#{@file1_css_digest}.css?body=1" media="screen" rel="stylesheet" />\n<link href="/assets/file2.self-#{@file2_css_digest}.css?body=1" media="screen" rel="stylesheet" />),
+    assert_dom_equal %(<link href="/assets/dependency.self-#{@dependency_css_digest}.css?body=1" media="screen" rel="stylesheet" />\n<link href="/assets/file1.self-#{@file1_css_debug_digest}.css?body=1" media="screen" rel="stylesheet" />\n<link href="/assets/file2.self-#{@file2_css_debug_digest}.css?body=1" media="screen" rel="stylesheet" />),
       @view.stylesheet_link_tag(:file1, :file2)
 
     assert_servable_asset_url "/assets/foo-#{@foo_css_digest}.css?body=1"

--- a/test/test_railtie.rb
+++ b/test/test_railtie.rb
@@ -243,7 +243,7 @@ class TestRailtie < TestBoot
     app.initialize!
 
     assert manifest = app.assets_manifest
-    assert_match %r{test_public/assets/manifest-.*\.json$}, manifest.path
+    assert_match %r{test_public/assets/.sprockets-manifest-.*\.json$}, manifest.path
     assert_match %r{test_public/assets$}, manifest.dir
   end
 

--- a/test/test_task.rb
+++ b/test/test_task.rb
@@ -76,7 +76,7 @@ class TestTask < Minitest::Test
     @rake['assets:precompile'].invoke
 
     assert @environment_ran
-    assert Dir["#{@dir}/manifest-*.json"].first
+    assert Dir["#{@dir}/.sprockets-manifest-*.json"].first
     assert File.exist?("#{@dir}/#{digest_path}")
   end
 

--- a/test/test_task.rb
+++ b/test/test_task.rb
@@ -112,6 +112,7 @@ class TestTask < Minitest::Test
     new_path = path.join("../foo-modified.js")
 
     FileUtils.cp(path, new_path)
+    FileUtils.touch(new_path, :mtime => Time.now - 3600)
 
     assert File.exist?(new_path)
     digest_path = @assets['foo-modified.js'].digest_path


### PR DESCRIPTION
Many of Sprockets behaviors changed since its v3.0.0.beta8 version. This adjusts the test suite accordingly.

The only user-facing change is that the gemfile now requires Sprockets `>= 3.0.0`, i.e. v3.0.0.beta8 is no longer supported.

/cc @josh 