### PR TITLE
Avoid compiling all assets when computing a single asset path

### DIFF
--- a/lib/sprockets/rails/helper.rb
+++ b/lib/sprockets/rails/helper.rb
@@ -86,11 +86,6 @@ module Sprockets
 
         if environment = assets_environment
           if asset = environment[path]
-            unless options[:debug]
-              if !precompiled_assets.include?(asset)
-                raise AssetNotPrecompiled.new(asset.logical_path)
-              end
-            end
             return asset.digest_path
           end
         end
@@ -215,13 +210,7 @@ module Sprockets
             path = "#{path}#{extname}"
           end
 
-          if asset = env[path]
-            if !precompiled_assets.include?(asset)
-              raise AssetNotPrecompiled.new(asset.logical_path)
-            end
-          end
-
-          asset
+          env[path]
         end
 
         # Internal: Generate a Set of all precompiled assets.

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -658,9 +658,9 @@ class AssetUrlHelperLinksTarget < HelperTest
     assert @view.asset_path("url.css")
     assert @view.asset_path("logo.png")
 
-    assert_raises(Sprockets::Rails::Helper::AssetNotPrecompiled) do
-      @view.asset_path("foo.css")
-    end
+    # assert_raises(Sprockets::Rails::Helper::AssetNotPrecompiled) do
+    #   @view.asset_path("foo.css")
+    # end
   end
 
   def test_links_image_target


### PR DESCRIPTION
This allows `stylesheet_link_tag` to generate a link for one CSS bundle without also forcing compilation of all unrelated CSS and JS assets.

This reverts a feature added in https://github.com/github/sprockets-rails/commit/6e7a69b3436d6976a1f1f13d3257231cc2e52c3a#diff-ddaedf4f21ca59b645bd6cfa3b2d50beR86

/cc @josh